### PR TITLE
Add interactive course prerequisite map

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,101 @@
+async function loadCourses() {
+  const response = await fetch('materias_prerequisitos.csv');
+  const text = await response.text();
+  const data = parseCSV(text);
+  renderCourses(data);
+  drawConnections();
+  window.addEventListener('resize', drawConnections);
+}
+
+function parseCSV(text) {
+  const lines = text.trim().split('\n').slice(1);
+  return lines.map(line => {
+    let inQuotes = false;
+    let field = '';
+    const fields = [];
+    for (const char of line) {
+      if (char === '"') {
+        inQuotes = !inQuotes;
+      } else if (char === ',' && !inQuotes) {
+        fields.push(field);
+        field = '';
+      } else {
+        field += char;
+      }
+    }
+    fields.push(field);
+    const [code, name, prereqStr] = fields;
+    return {
+      code: code.trim(),
+      name: name.trim(),
+      prereqs: prereqStr.trim().split(/\s+/).filter(Boolean)
+    };
+  });
+}
+
+const courseMap = new Map();
+
+function renderCourses(courses) {
+  const container = document.getElementById('course-container');
+  container.innerHTML = '';
+  courses.forEach(course => {
+    const div = document.createElement('div');
+    div.className = 'course';
+    div.dataset.code = course.code;
+    div.innerHTML = `<strong>${course.code}</strong><br>${course.name}`;
+    div.addEventListener('click', () => toggleSelect(course.code));
+    container.appendChild(div);
+    course.element = div;
+    courseMap.set(course.code, course);
+  });
+}
+
+function toggleSelect(code) {
+  const course = courseMap.get(code);
+  if (!course) return;
+  if (course.element.classList.contains('selected')) {
+    course.element.classList.remove('selected');
+  } else {
+    selectWithPrereqs(code, new Set());
+  }
+}
+
+function selectWithPrereqs(code, visited) {
+  if (visited.has(code)) return;
+  visited.add(code);
+  const course = courseMap.get(code);
+  if (!course) return;
+  course.element.classList.add('selected');
+  course.prereqs.forEach(pr => selectWithPrereqs(pr, visited));
+}
+
+function drawConnections() {
+  const svg = document.getElementById('connections');
+  const diagram = document.getElementById('diagram');
+  svg.setAttribute('width', diagram.offsetWidth);
+  svg.setAttribute('height', diagram.offsetHeight);
+  svg.innerHTML = '';
+  courseMap.forEach(course => {
+    const rect1 = course.element.getBoundingClientRect();
+    const dRect = diagram.getBoundingClientRect();
+    const x1 = rect1.left + rect1.width / 2 - dRect.left;
+    const y1 = rect1.top + rect1.height / 2 - dRect.top;
+    course.prereqs.forEach(pr => {
+      const prereq = courseMap.get(pr);
+      if (!prereq) return;
+      const rect2 = prereq.element.getBoundingClientRect();
+      const x2 = rect2.left + rect2.width / 2 - dRect.left;
+      const y2 = rect2.top + rect2.height / 2 - dRect.top;
+      const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+      line.setAttribute('x1', x1);
+      line.setAttribute('y1', y1);
+      line.setAttribute('x2', x2);
+      line.setAttribute('y2', y2);
+      line.setAttribute('stroke', 'rgba(255,255,255,0.3)');
+      line.setAttribute('stroke-width', '2');
+      svg.appendChild(line);
+    });
+  });
+}
+
+loadCourses();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mapa de Materias</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="diagram">
+    <div id="course-container"></div>
+    <svg id="connections"></svg>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,60 @@
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  color: #fff;
+  background: linear-gradient(135deg, #00a86b, #0d1117);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#diagram {
+  position: relative;
+  width: 100%;
+  max-width: 1200px;
+  padding: 40px;
+  box-sizing: border-box;
+}
+
+#course-container {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 20px;
+}
+
+@media (max-width: 1000px) {
+  #course-container {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  #course-container {
+    grid-template-columns: repeat(1, 1fr);
+  }
+}
+
+.course {
+  backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 12px;
+  padding: 15px;
+  cursor: pointer;
+  transition: background 0.3s, border-color 0.3s;
+}
+
+.course.selected {
+  background: rgba(0, 168, 107, 0.4);
+  border-color: rgba(0, 168, 107, 0.7);
+}
+
+#connections {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- Display course cards parsed from `materias_prerequisitos.csv` in a 5-column responsive grid.
- Draw SVG lines connecting each course to its prerequisites and auto-select prerequisites when a course is chosen.
- Apply modern glassmorphic design with jade/obsidian gradients and selectable cards.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b38fa0943c83279fa338f1d4dcb45f